### PR TITLE
增加模块接收方式

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -6,10 +6,12 @@
 
 module.exports = {
     getModuleExports: function (mod) {
+        var returns;
         if (!mod.exports) {
             mod.exports = {};
-            mod.factory(mcmd.require, mod.exports, mod);
+            returns = mod.factory(mcmd.require, mod.exports, mod);
         }
-        return mod.exports;
+        //优先使用return传递的模块接口
+        return returns || mod.exports;
     }
 };


### PR DESCRIPTION
seaJS在实现模块接口接收时，不仅支持exports、module，也支持return返回接口的接收，而且优先级大于前者。

当然，在CMD相关规范里并未找到这一条，仅根据 seaJS 作为 CMD 事实上的标准来参考。
